### PR TITLE
DateRangePicker not shown next month

### DIFF
--- a/dist/js/jquery.datepicker.js
+++ b/dist/js/jquery.datepicker.js
@@ -2131,7 +2131,7 @@
       newMonth = month === 0 ? 11 : month - 1,
       newMonthDayCount = $.getTotalDayCountOfMonth(newYear, newMonth);
 
-    newDate.setMonth(newMonth);
+    newDate.setMonth(newMonth, 1);
     newDate.setFullYear(newYear);
 
     if (newMonthDayCount < date) {
@@ -2149,7 +2149,7 @@
       newMonth = month === 11 ? 0 : month + 1,
       newMonthDayCount = $.getTotalDayCountOfMonth(newYear, newMonth);
 
-    newDate.setMonth(newMonth);
+    newDate.setMonth(newMonth, 1);
     newDate.setFullYear(newYear);
 
     if (newMonthDayCount < date) {
@@ -2167,7 +2167,7 @@
       newMonth = month,
       newMonthDayCount = $.getTotalDayCountOfMonth(newYear, newMonth);
 
-    newDate.setMonth(newMonth);
+    newDate.setMonth(newMonth, 1);
     newDate.setFullYear(newYear);
 
     if (newMonthDayCount < date) {
@@ -2185,7 +2185,7 @@
       newMonth = month,
       newMonthDayCount = $.getTotalDayCountOfMonth(newYear, newMonth);
 
-    newDate.setMonth(newMonth);
+    newDate.setMonth(newMonth, 1);
     newDate.setFullYear(newYear);
 
     if (newMonthDayCount < date) {


### PR DESCRIPTION
When the DateRangePicker is used and the date of the current month is greater than the date of the next month, the next month is not shown. For example: If today is January 29, the month of February will not be shown, as February does not have the 29th.